### PR TITLE
Scale up size of player helmet model

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -28,7 +28,10 @@ namespace LCUltrawide
 
             configResW = Config.Bind("Resolution", "Width", 860, "Horizontal rendering resolution");
             configResH = Config.Bind("Resolution", "Height", 520, "Vertical rendering resolution");
-            
+
+            // Calculate new aspect ratio
+            fNewAspect = configResW.Value / (float)configResH.Value;
+
             configUIScale = Config.Bind("UI", "Scale", 3.2f, "Changes the size of UI elements on the screen");
             configUIAspect = Config.Bind("UI", "AspectRatio", 1.77f, "Changes the aspect ratio of the ingame HUD, a higher number makes the HUD wider (4:3 = 1.33, 16:9 = 1.77, 21:9 = 2.33, 32:9 = 3.55)");
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -17,6 +17,10 @@ namespace LCUltrawide
         private static ConfigEntry<float> configUIScale;
         private static ConfigEntry<float> configUIAspect;
 
+        // Aspect Ratio
+        public static float fDefaultAspect = 860 / (float)520;
+        public static float fNewAspect;
+
         private void Awake()
         {
             // Plugin startup logic
@@ -78,6 +82,20 @@ namespace LCUltrawide
                     rectTransform.anchorMax = new Vector2(0.5f, 0f);
                     rectTransform.anchorMin = new Vector2(0.5f, 0.5f);
                     rectTransform.pivot = new Vector2(0.5f, 0f);
+                }
+            }
+
+            //Scale up width of helmet model
+            GameObject helmetModel = GameObject.Find("ScavengerHelmet");
+            if (helmetModel != null)
+            {
+                if (helmetModel.TryGetComponent<Transform>(out Transform transform))
+                {
+                    float fDefaultHelmetWidth = 0.5136268f;
+                    Vector3 helmetScale = transform.localScale;
+                    // Helmet width is good up until an aspect ratio of 1.925~
+                    helmetScale.x = fDefaultHelmetWidth * (fNewAspect / 1.925f);
+                    transform.localScale = helmetScale;
                 }
             }
         }


### PR DESCRIPTION
By default the player helmet only really fits correctly up until an aspect ratio of around 1.925~ by my eye. This PR adds width scaling to the helmet so it's less intrusive at higher aspect ratios.

The difference is quite profound at 32:9 for example.

Before:
![Lethal Company_2023_11_25_14_47_08_836](https://github.com/stefan750/LCUltrawide/assets/695941/90e4d865-c111-4867-a4d4-0ac5a49d79fd)

After:
![Lethal Company_2023_11_25_14_43_22_823](https://github.com/stefan750/LCUltrawide/assets/695941/dc8042a5-76d7-4a33-82fe-bbd9a074f7f7)
