### PR TITLE
Fix Terminal Resolution

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -35,8 +35,16 @@ namespace LCUltrawide
         [HarmonyPrefix]
         static void PlayerControllerStart(PlayerControllerB __instance)
         {
-            //Change camera render texture resolution
+            //Change camera render texture resolution and terminal resolution
             RenderTexture screenTex = __instance.gameplayCamera.targetTexture;
+            RenderTexture terminalTexHighRes = GameObject.Find("TerminalScript").GetComponent<Terminal>().playerScreenTexHighRes;
+            RenderTexture terminalTex = GameObject.Find("TerminalScript").GetComponent<Terminal>().playerScreenTex;
+            
+            terminalTex.width = configResW.Value;
+            terminalTex.height = configResH.Value;
+
+            terminalTexHighRes.width = configResW.Value;
+            terminalTexHighRes.height = configResH.Value;
 
             screenTex.width = configResW.Value;
             screenTex.height = configResH.Value;


### PR DESCRIPTION
Currently, if you enter the terminal, the resolution resets to the default resolution.

This change targets the component and field that changes the resolution when you enter the terminal, and changes it to the configuration settings.

This is my first pull request ever. Please let me know if I am doing something horribly wrong or if my code is really bad. It likely is, and I am not sure if using GameObject.Find to target the terminal component is bad practice or not.